### PR TITLE
Steelconnect data refactor

### DIFF
--- a/Assets/Scripts/Lib/SteelConnect.cs
+++ b/Assets/Scripts/Lib/SteelConnect.cs
@@ -4,13 +4,20 @@ using System.Collections.Generic;
 using UnityEngine;
 
 // For promises and REST client.
+// We're using promises/futures here for async operations. See:
+// https://github.com/Real-Serious-Games/C-Sharp-Promise
+// https://github.com/proyecto26/RestClient/
 using RSG;
 using Proyecto26;
 using Models.SteelConnect;
 
-// We're using promises/futures here for async operations. See:
-// https://github.com/Real-Serious-Games/C-Sharp-Promise
-// https://github.com/proyecto26/RestClient/
+// These are just to make it clearer what each function or type expects.
+// These aliases are all just equivalent to `string`, and so you can pass strings with no problems.
+using OrgId = System.String;
+using SiteId = System.String;
+using WanId = System.String;
+using UplinkId = System.String;
+using SitelinkId = System.String;
 
 public class SteelConnect {
     static readonly string
@@ -19,9 +26,10 @@ public class SteelConnect {
         API_REPORTING = "scm.reporting",
         API_REPORTING_VERSION = "1.0";
 
-    private string username, password, baseUrl, orgId;
+    private string username, password, baseUrl;
+    private OrgId orgId;
 
-    public SteelConnect(string username, string password, string baseUrl, string orgId) {
+    public SteelConnect(string username, string password, string baseUrl, OrgId orgId) {
         this.username = username;
         this.password = password;
         this.baseUrl = baseUrl;
@@ -77,36 +85,36 @@ public class SteelConnect {
 
     // ---
 
-    public IPromise<Sites> GetSitesInOrg() {
-        return RestClient.Get<Sites>(newConfigRequest("/org/" + orgId + "/sites"));
+    public IPromise<SiteItems> GetSitesInOrg() {
+        return RestClient.Get<SiteItems>(newConfigRequest("/org/" + orgId + "/sites"));
     }
 
-    public IPromise<ResponseHelper> DeleteSite(string siteId) {
+    public IPromise<ResponseHelper> DeleteSite(SiteId siteId) {
         return RestClient.Delete(newConfigRequest("/site/" + siteId));
     }
 
-    public IPromise<Wans> GetWansInOrg() {
-        return RestClient.Get<Wans>(newConfigRequest("/org/" + orgId + "/wans"));
+    public IPromise<WanItems> GetWansInOrg() {
+        return RestClient.Get<WanItems>(newConfigRequest("/org/" + orgId + "/wans"));
     }
 
-    public IPromise<Uplinks> GetUplinksInOrg() {
-        return RestClient.Get<Uplinks>(newConfigRequest("/org/" + orgId + "/uplinks"));
+    public IPromise<UplinkItems> GetUplinksInOrg() {
+        return RestClient.Get<UplinkItems>(newConfigRequest("/org/" + orgId + "/uplinks"));
     }
 
-    public IPromise<Sitelinks> GetSitelinks(string siteId) {
+    public IPromise<SitelinkReportingItems> GetSitelinks(SiteId siteId) {
         // Since using standard RestClient with returning a promise counts any non-200
         // status code as an error, but 404 is a potentially valid response for no sitelinks,
         // we need to build the promise manually ourselves.
-        var sitelinksPromise = new Promise<Sitelinks>();
+        var sitelinksPromise = new Promise<SitelinkReportingItems>();
         
-        RestClient.Get<Sitelinks>(newReportingRequest("/site/" + siteId + "/sitelinks"), (err, resp, sitelinks) => {
+        RestClient.Get<SitelinkReportingItems>(newReportingRequest("/site/" + siteId + "/sitelinks"), (err, resp, sitelinks) => {
             if (err == null) {
                 Debug.Log($"Site {siteId} has {sitelinks.items.Length} sitelink(s)");
                 sitelinksPromise.Resolve(sitelinks);
             } else if (err.StatusCode == 404) {
                 // No sitelinks, return empty list.
                 Debug.Log($"Site {siteId} has no sitelinks");
-                sitelinksPromise.Resolve(new Sitelinks { items = new Sitelink[] { } });
+                sitelinksPromise.Resolve(new SitelinkReportingItems { items = new SitelinkReporting[] { } });
             } else {
                 sitelinksPromise.Reject(err);
             }
@@ -120,7 +128,7 @@ public class SteelConnect {
 namespace Models {
     namespace SteelConnect {
         [Serializable]
-        public class Sites {
+        public class SiteItems {
             public Site[] items;
         }
 
@@ -136,12 +144,12 @@ namespace Models {
         }
 
         [Serializable]
-        public class Sitelinks {
-            public Sitelink[] items;
+        public class SitelinkReportingItems {
+            public SitelinkReporting[] items;
         }
 
         [Serializable]
-        public class Sitelink {
+        public class SitelinkReporting {
             public string id;
             public string remote_site;
             public string state;
@@ -149,7 +157,7 @@ namespace Models {
         }
 
         [Serializable]
-        public class Wans {
+        public class WanItems {
             public Wan[] items;
         }
 
@@ -163,7 +171,7 @@ namespace Models {
         }
 
         [Serializable]
-        public class Uplinks {
+        public class UplinkItems {
             public Uplink[] items;
         }
 
@@ -177,5 +185,4 @@ namespace Models {
             public string node;
         }
     }
-
 }

--- a/Assets/Scripts/Lib/SteelConnect.cs
+++ b/Assets/Scripts/Lib/SteelConnect.cs
@@ -141,6 +141,9 @@ namespace Models {
             public string country;
             public string city;
             public string street_address;
+
+            // Not part of the API response, but added later by SteelConnectDataManager.
+            public LatLong coordinates;
         }
 
         [Serializable]

--- a/Assets/Scripts/StateManager.cs
+++ b/Assets/Scripts/StateManager.cs
@@ -34,8 +34,6 @@ public class StateManager : MonoBehaviour {
     private Dictionary<SiteId, SiteMarker> currentSiteMarkers;
     private List<LineMarker> currentLineMarkers;
 
-    private SteelConnect steelConnect;
-
     // Use this for initialization
     void Start () {
         currentSiteMarkers = new Dictionary<SiteId, SiteMarker>();

--- a/Assets/Scripts/StateManager.cs
+++ b/Assets/Scripts/StateManager.cs
@@ -8,11 +8,15 @@ using RSG;
 using Proyecto26;
 using Models.SteelConnect;
 
-// Type alias for clarity.
-using SiteID = System.String;
+// These are just to make it clearer what each function or type expects.
+// These aliases are all just equivalent to `string`, and so you can pass strings with no problems.
+using OrgId = System.String;
+using SiteId = System.String;
+using WanId = System.String;
+using UplinkId = System.String;
+using SitelinkId = System.String;
 
 public class StateManager : MonoBehaviour {
-
     public GameObject laser;
     public GameObject confirm;
     public bool deleteMode = false;
@@ -23,19 +27,21 @@ public class StateManager : MonoBehaviour {
 
     private GameObject _tempObject;
 
+    private SteelConnectDataManager _dataManager;
+
     // Site marker code
-    public Dictionary<SiteID, GameObject> currentSiteMarkerObjects = new Dictionary<SiteID, GameObject>();
-    private Dictionary<SiteID, SiteMarker> currentSiteMarkers;
+    public Dictionary<SiteId, GameObject> currentSiteMarkerObjects = new Dictionary<SiteId, GameObject>();
+    private Dictionary<SiteId, SiteMarker> currentSiteMarkers;
     private List<LineMarker> currentLineMarkers;
 
     private SteelConnect steelConnect;
 
     // Use this for initialization
     void Start () {
-        currentSiteMarkers = new Dictionary<string, SiteMarker>();
+        currentSiteMarkers = new Dictionary<SiteId, SiteMarker>();
         currentLineMarkers = new List<LineMarker>();
 
-        steelConnect = new SteelConnect();
+        _dataManager = GameObject.Find("State Manager").GetComponent<SteelConnectDataManager>();
 
         confirm.SetActive(false);
 	}
@@ -45,16 +51,22 @@ public class StateManager : MonoBehaviour {
         if (Input.GetKeyDown("s")) {
             GetComponent<WanManager>().UpdateWans();
         } else if (Input.GetKeyDown("a")) {
-            UpdateSites();
+            UpdateSites(true);
         }
 	}
 
     // Update Sites
-    public void UpdateSites()
+    public void UpdateSitesForceRefresh() {
+        UpdateSites(true);
+    }
+
+    public void UpdateSites(bool forceRefresh)
     {
         foreach (var entry in currentSiteMarkers)
         {
-            if (entry.Value) Destroy(entry.Value.gameObject);
+            if (entry.Value) {
+                Destroy(entry.Value.gameObject);
+            }
         }
         currentSiteMarkers.Clear();
         currentSiteMarkerObjects.Clear();
@@ -67,80 +79,46 @@ public class StateManager : MonoBehaviour {
 
         // ---
 
-        // What follows is a whole lot of promise-based async code.
-        // TODO: I promise I'll explain what each promise is for.
+        var siteMarkersPromise = _dataManager.GetSites(forceRefresh)
+            .Then(sites => {
+                Dictionary<SiteId, SiteMarker> siteMarkers = new Dictionary<SiteId, SiteMarker>();
 
-        // Gets the list of sites from the SteelConnect API and returns it as an array of Sites.
-        var sitesPromise = steelConnect.GetSitesInOrg()
-            .Then(sites => { Debug.Log($"Got {sites.items.Count()} sites"); return sites.items; });
-
-        var latLongPromise = sitesPromise
-            .ThenAll(sites => sites.Select(site => LatLongUtility.GetLatLongForAddress(site.street_address, site.city, site.country)));
-
-        // Info on PromiseHelpers.All: https://github.com/Real-Serious-Games/C-Sharp-Promise/issues/33
-        var siteMarkersPromise = PromiseHelpers.All(sitesPromise, latLongPromise)
-            .Then(tup => {
-                Site[] sites = tup.Item1;
-                IEnumerable<LatLong> latLongs = tup.Item2;
-                Dictionary<SiteID, SiteMarker> siteMarkers = new Dictionary<SiteID, SiteMarker>();
-
-                for (int i = 0; i < sites.Count(); ++i)
-                {
-                    Site site = sites[i];
-                    if (latLongs.ElementAt(i).isValid)
+                foreach (Site site in sites) {
+                    if (site.coordinates.isValid)
                     {
                         if (earthSphere.activeSelf)
                         {
-                            siteMarkers.Add(site.id, earthSphere.GetComponent<GlobeSiteCreation>().placeSiteMarker(site, latLongs.ElementAt(i)));
+                            siteMarkers.Add(site.id, earthSphere.GetComponent<GlobeSiteCreation>().placeSiteMarker(site, site.coordinates));
                         }
                         else
                         {
-                            siteMarkers.Add(site.id, flatMap.GetComponent<FlatSiteCreation>().placeSiteMarker(site, latLongs.ElementAt(i)));
+                            siteMarkers.Add(site.id, flatMap.GetComponent<FlatSiteCreation>().placeSiteMarker(site, site.coordinates));
                         }
                     }
                     else
                     {
-                        Debug.LogWarning($"LatLong for site {site.id} is not valid, not adding site marker");
+                        Debug.LogWarning($"Coordinates for site {site.id} are not valid, not adding site marker");
                     }
                 }
 
                 return siteMarkers;
             });
 
-        var sitelinksPromise = sitesPromise
-            .ThenAll(sites => sites.Select(site => steelConnect.GetSitelinks(site.id)))
-            .Then(sitelinksList => sitelinksList.Select(sitelinks => sitelinks.items));
-
-        var sitelinksDictPromise = PromiseHelpers.All(sitesPromise, sitelinksPromise)
+        var sitelinkMarkersPromise = PromiseHelpers.All(siteMarkersPromise, _dataManager.GetSitelinks(forceRefresh))
             .Then(tup => {
-                Site[] sites = tup.Item1;
-                IEnumerable<Sitelink[]> sitelinks = tup.Item2;
-                Dictionary<SiteID, Sitelink[]> sitelinksDict = new Dictionary<SiteID, Sitelink[]>();
+                Dictionary<SiteId, SiteMarker> siteMarkers = tup.Item1;
+                Dictionary<SiteId, List<SitelinkReporting>> sitelinks = tup.Item2;
 
-                for (int i = 0; i < sites.Count(); ++i)
-                {
-                    sitelinksDict.Add(sites[i].id, sitelinks.ElementAt(i));
-                }
-
-                return sitelinksDict;
-            });
-
-        // Connect random pairs of sites, just for something to show.
-        var arbitraryLineMarkersPromise = PromiseHelpers.All(siteMarkersPromise, sitelinksDictPromise)
-            .Then(tup => {
-                Dictionary<SiteID, SiteMarker> siteMarkers = tup.Item1;
-                Dictionary<SiteID, Sitelink[]> sitelinks = tup.Item2;
-
-                // NOTE: Iterating through the sitemarkers dictionary means that if a site didn't
+                // NOTE(andrew): Iterating through the sitemarkers dictionary means that if a site didn't
                 // have a sitemarker, that site will be skipped. The same check is done later for the
                 // remote site (because we get sitelinks for all sites regardless of if they hasd a sitemarker
                 // created).
                 foreach (var siteMarkerEntry in siteMarkers)
                 {
-                    SiteID siteId = siteMarkerEntry.Key;
+                    SiteId siteId = siteMarkerEntry.Key;
                     SiteMarker siteMarker = siteMarkerEntry.Value;
 
-                    foreach (Sitelink sitelink in sitelinks[siteId])
+                    foreach (SitelinkReporting sitelink in sitelinks[siteId])
                     {
                         Debug.Log($"Sitelink {sitelink.id} between {siteId} and {sitelink.remote_site}: status({sitelink.status}) state({sitelink.state})");
 
@@ -242,6 +220,6 @@ public class StateManager : MonoBehaviour {
         earthSphere.SetActive(!earthSphere.activeSelf);
         flatMap.SetActive(!flatMap.activeSelf);
 
-        UpdateSites();
+        UpdateSites(false);
     }
 }

--- a/Assets/SteelConnectDataManager.cs
+++ b/Assets/SteelConnectDataManager.cs
@@ -40,7 +40,11 @@ public class SteelConnectDataManager : MonoBehaviour {
     private void Start() {
         _steelConnect = new SteelConnect();
 
+        // Preload data.
         GetSites(true);
+        GetWans(true);
+        GetUplinks(true);
+        GetSitelinks(true);
     }
 
     // ---
@@ -97,7 +101,7 @@ public class SteelConnectDataManager : MonoBehaviour {
 
     public IPromise<Dictionary<SiteId, List<SitelinkReporting>>> GetSitelinks(bool forceRefresh) {
         if (forceRefresh || _sitelinksPromise == null) {
-            _sitelinksPromise = GetSites(false)
+            _sitelinksPromise = GetSites(forceRefresh)
                 .ThenAll(sites => sites.Select(site => _steelConnect.GetSitelinks(site.id)))
                 .Then(sitelinksList => {
                     _sitelinkReportings = new Dictionary<SiteId, List<SitelinkReporting>>();

--- a/Assets/SteelConnectDataManager.cs
+++ b/Assets/SteelConnectDataManager.cs
@@ -1,0 +1,120 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+using System.Linq;
+
+// Promises and SteelConnect API access.
+using RSG;
+using Proyecto26;
+using Models.SteelConnect;
+
+// These are just to make it clearer what each function or type expects.
+// These aliases are all just equivalent to `string`, and so you can pass strings with no problems.
+using OrgId = System.String;
+using SiteId = System.String;
+using WanId = System.String;
+using UplinkId = System.String;
+using SitelinkId = System.String;
+
+public class SteelConnectDataManager : MonoBehaviour {
+    private SteelConnect _steelConnect;
+
+    // Stored data. This data pertains to a single organization in a single realm.
+    private List<Site> _baseSites = null;
+    private List<SiteData> _sites = null; // Sites with coordinates.
+    private List<Wan> _wans = null;
+    private List<Uplink> _uplinks = null;
+
+    private Dictionary<SiteId, List<SitelinkReporting>> _sitelinkReportings = null;
+
+    // ---
+
+    // Initialization is done here.
+    private void Awake() {
+        _steelConnect = new SteelConnect();
+    }
+
+    // ---
+
+    public IPromise<List<SiteData>> GetSites(bool forceRefresh) {
+        if (forceRefresh || _sites == null) {
+            return _steelConnect.GetSitesInOrg()
+                .Then(items => {
+                    // Save the API sites for later.
+                    _baseSites = new List<Site>(items.items);
+                    return _baseSites;
+                })
+                .ThenAll(sites => {
+                    return sites.Select(site => LatLongUtility.GetLatLongForAddress(site.street_address, site.city, site.country));
+                })
+                .Then(latLongs => {
+                    _sites = new List<SiteData>();
+
+                    // We now have an IEnumerable called latLongs (think of it like a list) that has elements of LatLong.
+                    // Each element of latLongs corresponds to the site in _baseSites with the same index.
+                    // We use this fact to link sites to their LatLongs.
+                    for (int i = 0; i < _baseSites.Count; ++i) {
+                        _sites.Append(new SiteData(_baseSites[i], latLongs.ElementAt(i)));
+                    }
+
+                    return _sites;
+                });
+        } else {
+            return Promise<List<SiteData>>.Resolved(_sites);
+        }
+    }
+
+    public IPromise<List<Wan>> GetWans(bool forceRefresh) {
+        if (forceRefresh || _wans == null) {
+            return _steelConnect.GetWansInOrg()
+                .Then(items => {
+                    _wans = new List<Wan>(items.items);
+                    return _wans;
+                });
+        } else {
+            return Promise<List<Wan>>.Resolved(_wans);
+        }
+    }
+
+    public IPromise<List<Uplink>> GetUplinks(bool forceRefresh) {
+        if (forceRefresh || _uplinks == null) {
+            return _steelConnect.GetUplinksInOrg()
+                .Then(items => {
+                    _uplinks = new List<Uplink>(items.items);
+                    return _uplinks;
+                });
+        } else {
+            return Promise<List<Uplink>>.Resolved(_uplinks);
+        }
+    }
+
+    public IPromise<Dictionary<SiteId, List<SitelinkReporting>>> GetSitelinks(bool forceRefresh) {
+        if (forceRefresh || _sitelinkReportings == null) {
+            return GetSites(false)
+                .ThenAll(siteDatas => siteDatas.Select(siteData => _steelConnect.GetSitelinks(siteData.site.id)))
+                .Then(sitelinksList => {
+                    _sitelinkReportings = new Dictionary<SiteId, List<SitelinkReporting>>();
+
+                    for (int i = 0; i < _sites.Count; ++i) {
+                        _sitelinkReportings.Add(_sites[i].site.id, new List<SitelinkReporting>(sitelinksList.ElementAt(i).items));
+                    }
+
+                    return _sitelinkReportings;
+                });
+        } else {
+            return Promise<Dictionary<SiteId, List<SitelinkReporting>>>.Resolved(_sitelinkReportings);
+        }
+    }
+}
+
+// ---
+
+public class SiteData {
+    public Site site;
+    public LatLong coordinates;
+
+    public SiteData(Site site, LatLong coordinates) {
+        this.site = site;
+        this.coordinates = coordinates;
+    }
+}

--- a/Assets/SteelConnectDataManager.cs
+++ b/Assets/SteelConnectDataManager.cs
@@ -36,15 +36,8 @@ public class SteelConnectDataManager : MonoBehaviour {
 
     // ---
 
-    // Initialization is done here.
     private void Start() {
         _steelConnect = new SteelConnect();
-
-        // Preload data.
-        GetSites(true);
-        GetWans(true);
-        GetUplinks(true);
-        GetSitelinks(true);
     }
 
     // ---
@@ -101,7 +94,7 @@ public class SteelConnectDataManager : MonoBehaviour {
 
     public IPromise<Dictionary<SiteId, List<SitelinkReporting>>> GetSitelinks(bool forceRefresh) {
         if (forceRefresh || _sitelinksPromise == null) {
-            _sitelinksPromise = GetSites(forceRefresh)
+            _sitelinksPromise = GetSites(false)
                 .ThenAll(sites => sites.Select(site => _steelConnect.GetSitelinks(site.id)))
                 .Then(sitelinksList => {
                     _sitelinkReportings = new Dictionary<SiteId, List<SitelinkReporting>>();

--- a/Assets/SteelConnectDataManager.cs.meta
+++ b/Assets/SteelConnectDataManager.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 7f2e96eaa176807499eac25e52d037bd
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/WanManager.cs
+++ b/Assets/WanManager.cs
@@ -17,12 +17,12 @@ public class WanManager : MonoBehaviour {
     public Dictionary<string, Uplink> uplinks = new Dictionary<string, Uplink>();
 
     private List<Wan> _wans = new List<Wan>();
-    private SteelConnect _steelConnect;
-    private bool _showWans = false;
+    private SteelConnectDataManager _dataManager;
     private GlobeSiteCreation _globeSiteCreation;
+    private bool _showWans = false;
 
 	void Start () {
-        _steelConnect = new SteelConnect();
+        _dataManager = GameObject.Find("State Manager").GetComponent<SteelConnectDataManager>();
         _globeSiteCreation = earthSphere.GetComponent<GlobeSiteCreation>();
 	}
 
@@ -38,14 +38,14 @@ public class WanManager : MonoBehaviour {
         _wans.Clear();
         uplinks.Clear();
         // Get WANs from SteelConnect API
-        _steelConnect.GetWansInOrg()
-            .Then(wans => wans.items.ToList().ForEach(wan => {
+        _dataManager.GetWans(true)
+            .Then(wans => wans.ForEach(wan => {
                 _wans.Add(wan);
             }))
             .Then(() =>
                 // Get uplinks from SteelConnect API
-                _steelConnect.GetUplinksInOrg()
-                    .Then(uplinks => uplinks.items.ToList().ForEach(uplink => {
+                _dataManager.GetUplinks(true)
+                    .Then(uplinks => uplinks.ForEach(uplink => {
                         this.uplinks[uplink.id] = uplink;
                     })))
             .Then(() => {


### PR DESCRIPTION
This adds a new component to the State Manager, `SteelConnectDataManager`, which can be queried for SteelConnect API information. It caches the results of the API calls, unless the `Get*()` methods are called with `true`, forcing a data refresh.

I replaced the SteelConnect calls I could find in `StateManager.cs` and `WanManager.cs`, hopefully I didn't miss anything.

Also did some renaming in `SteelConnect.cs`, renaming the collection types to have `Items` as a suffix.