### PR TITLE
Add some default data to the data manager

### DIFF
--- a/Assets/SteelConnectDataManager.cs
+++ b/Assets/SteelConnectDataManager.cs
@@ -38,6 +38,12 @@ public class SteelConnectDataManager : MonoBehaviour {
 
     private void Start() {
         _steelConnect = new SteelConnect();
+
+        // Add some default data.
+        _sitesPromise = Promise<List<Site>>.Resolved(new List<Site>());
+        _wansPromise = Promise<List<Wan>>.Resolved(new List<Wan>());
+        _uplinksPromise = Promise<List<Uplink>>.Resolved(new List<Uplink>());
+        _sitelinksPromise = Promise<Dictionary<SiteId, List<SitelinkReporting>>>.Resolved(new Dictionary<SiteId, List<SitelinkReporting>>());
     }
 
     // ---


### PR DESCRIPTION
This is so when you query it for the first time without refreshing, instead of refreshing you get empty data.